### PR TITLE
allow for Host role to call activity, but at least check for manage channels first

### DIFF
--- a/general/activity.js
+++ b/general/activity.js
@@ -12,7 +12,7 @@ try {
 
 module.exports = new Command('activity', async (incomingMessage, args, {yuuko}) => {
 	const owner = config.owner || process.env.OWNER;
-	if (args.length > 0 && incomingMessage.author.id === owner) {
+	if (args.length > 0 && (incomingMessage.author.id === owner || (member.roles.cache.some(role => role.name === 'Host') && member.permissions.has(Permissions.FLAGS.MANAGE_CHANNELS)))) {
 		const channel = await yuuko.getChannel(args[0]);
 		const msg = await incomingMessage.channel.createMessage({
 			embed: {


### PR DESCRIPTION
Not super sure I like this solution but I don't want to hard code ids nor do I want to be the one to make the call of converting config.owner into an array of owners.